### PR TITLE
Add super-reactions to MESSAGE_REACTION_ADD and MESSAGE_REACTION_REMOVE

### DIFF
--- a/docs/topics/Gateway_Events.md
+++ b/docs/topics/Gateway_Events.md
@@ -904,14 +904,16 @@ Sent when a user adds a reaction to a message.
 
 ###### Message Reaction Add Event Fields
 
-| Field      | Type                                                         | Description                                                                                |
-| ---------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| user_id    | snowflake                                                    | ID of the user                                                                             |
-| channel_id | snowflake                                                    | ID of the channel                                                                          |
-| message_id | snowflake                                                    | ID of the message                                                                          |
-| guild_id?  | snowflake                                                    | ID of the guild                                                                            |
-| member?    | [member](#DOCS_RESOURCES_GUILD/guild-member-object) object   | Member who reacted if this happened in a guild                                             |
-| emoji      | a partial [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) object | Emoji used to react - [example](#DOCS_RESOURCES_EMOJI/emoji-object-standard-emoji-example) |
+| Field         | Type                                                         | Description                                                                                |
+| ------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| user_id       | snowflake                                                    | ID of the user                                                                             |
+| channel_id    | snowflake                                                    | ID of the channel                                                                          |
+| message_id    | snowflake                                                    | ID of the message                                                                          |
+| guild_id?     | snowflake                                                    | ID of the guild                                                                            |
+| member?       | [member](#DOCS_RESOURCES_GUILD/guild-member-object) object   | Member who reacted if this happened in a guild                                             |
+| emoji         | a partial [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) object | Emoji used to react - [example](#DOCS_RESOURCES_EMOJI/emoji-object-standard-emoji-example) |
+| burst         | boolean                                                      | true if this is a super-reaction                                                           |
+| burst_colors? | array of strings                                             | Colors used for super-reaction animation in "#rrggbb" format                               |
 
 #### Message Reaction Remove
 
@@ -926,6 +928,7 @@ Sent when a user removes a reaction from a message.
 | message_id | snowflake                                                    | ID of the message                                                                          |
 | guild_id?  | snowflake                                                    | ID of the guild                                                                            |
 | emoji      | a partial [emoji](#DOCS_RESOURCES_EMOJI/emoji-object) object | Emoji used to react - [example](#DOCS_RESOURCES_EMOJI/emoji-object-standard-emoji-example) |
+| burst      | boolean                                                      | true if this was a super-reaction                                                          |
 
 #### Message Reaction Remove All
 


### PR DESCRIPTION
This Pull Request adds to the open Pull Request discord/discord-api-docs#6056

I have observed these super-reaction related members in the MESSAGE_REACTION_ADD and MESSAGE_REACTION_REMOVE events as demonstrated below:

<details>
<summary>Add and Remove Screenshots</summary>

![Screenshot_20230714_133238](https://github.com/Mateo-tem/discord-api-docs/assets/5211576/b9689dc4-f2d7-4190-be64-e81c59e7c98b)


![Screenshot_20230714_133004-1](https://github.com/Mateo-tem/discord-api-docs/assets/5211576/85edc0aa-9a03-417a-8fad-5e35301b776b)

</details>

`burst_colors` was left out of MESSAGE_REACTION_REMOVE because my findings show it is always empty even if it was a super-reaction

I have also observed similar members in the MESSAGE_REACTION_REMOVE_EMOJI event, but they don't seem to work the same way so they were omitted.

<details>
<summary>Add and Remove All Emoji Screenshots</summary>

![Screenshot_20230714_134227-1](https://github.com/Mateo-tem/discord-api-docs/assets/5211576/3bfc7449-3f41-452f-9faf-8983b0ab26c1)

![Screenshot_20230714_135019](https://github.com/Mateo-tem/discord-api-docs/assets/5211576/0e692dfa-a6b2-4536-b800-4374a77c239f)

</details>